### PR TITLE
Add image archive tags and branch name patterns for triggering builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ pr:
 
 variables:
   IMAGE_NAME: steamcmd
+  IMAGE_TAG_ARCHIVE: 20181201.0
 
 jobs:
 - job: Linux
@@ -59,6 +60,7 @@ jobs:
           -t "${REPOSITORY}:${VARIANT}" \
           --label "game_distributor=steamcmd" \
           "${VARIANT}/"
+      docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${IMAGE_TAG_ARCHIVE}"
       if [ "$LATEST" = 'true' ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:latest"
       fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,10 +64,10 @@ jobs:
           -t "${REPOSITORY}:${VARIANT}" \
           --label "game_distributor=steamcmd" \
           "${VARIANT}/"
-      if [ "$LATEST" = 'true' ]; then
+      if [ "${LATEST}" = 'true' ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:latest"
       fi
-      if [ -n "$COMMIT_TAG" ]; then
+      if [ -n "${COMMIT_TAG}" ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${COMMIT_TAG}"
       fi
       date
@@ -87,9 +87,11 @@ jobs:
   - script: |
       set -e
       # Push the image
-      date
-      docker push "${REPOSITORY}"
-      date
+      if [ -n "${COMMIT_TAG}" ]; then
+          date
+          docker push "${REPOSITORY}"
+          date
+      fi
     displayName: Push SteamCMD Image
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,8 @@
 trigger:
   branches:
     include:
+      - build/*
       - master
-  tags:
-    include:
-      - '*'
 pr:
   branches:
     include:
@@ -43,13 +41,13 @@ jobs:
     displayName: System Info
   - script: |
       REPOSITORY="${REGISTRY_NAMESPACE}/${IMAGE_NAME}"
-      COMMIT_TAG=$( echo "${BUILD_SOURCEBRANCH}" | sed -rn 's/^refs\/tags\/(.*)/\1/p' )
+      BUILD_TAG=$( echo "${BUILD_SOURCEBRANCH}" | sed -rn 's/^refs\/heads\/build\/(.*)/\1/p' )
 
       echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin
 
       # Set job-scoped variables
       echo "##vso[task.setvariable variable=REPOSITORY]${REPOSITORY}"
-      echo "##vso[task.setvariable variable=COMMIT_TAG]${COMMIT_TAG}"
+      echo "##vso[task.setvariable variable=BUILD_TAG]${BUILD_TAG}"
     env:
       REGISTRY_PASSWORD: $(REGISTRY_PASSWORD)
     displayName: Before Script
@@ -67,8 +65,8 @@ jobs:
       if [ "${LATEST}" = 'true' ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:latest"
       fi
-      if [ -n "${COMMIT_TAG}" ]; then
-          docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${COMMIT_TAG}"
+      if [ -n "${BUILD_TAG}" ]; then
+          docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${BUILD_TAG}"
       fi
       date
       echo; docker images
@@ -87,13 +85,13 @@ jobs:
   - script: |
       set -e
       # Push the image
-      if [ -n "${COMMIT_TAG}" ]; then
+      if [ -n "${BUILD_TAG}" ]; then
           date
           docker push "${REPOSITORY}"
           date
       fi
     displayName: Push SteamCMD Image
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/build/')
   - script: |
       docker logout
     displayName: After Script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pr:
 
 variables:
   IMAGE_NAME: steamcmd
-  IMAGE_TAG_ARCHIVE: 20181201.0
+  IMAGE_ARCHIVE_TAG: 20181201.0
 
 jobs:
 - job: Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
           -t "${REPOSITORY}:${VARIANT}" \
           --label "game_distributor=steamcmd" \
           "${VARIANT}/"
-      docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${IMAGE_TAG_ARCHIVE}"
+      docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${IMAGE_ARCHIVE_TAG}"
       if [ "$LATEST" = 'true' ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:latest"
       fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
           -t "${REPOSITORY}:${VARIANT}" \
           --label "game_distributor=steamcmd" \
           "${VARIANT}/"
-      docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${IMAGE_TAG_ARCHIVE}"
+      docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${IMAGE_TAG_ARCHIVE}"
       if [ "$LATEST" = 'true' ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:latest"
       fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,10 @@
 trigger:
   branches:
     include:
-    - master
+      - master
+  tags:
+    include:
+      - '*'
 pr:
   branches:
     include:
@@ -9,7 +12,6 @@ pr:
 
 variables:
   IMAGE_NAME: steamcmd
-  IMAGE_ARCHIVE_TAG: 20181201.0
 
 jobs:
 - job: Linux
@@ -41,11 +43,13 @@ jobs:
     displayName: System Info
   - script: |
       REPOSITORY="${REGISTRY_NAMESPACE}/${IMAGE_NAME}"
+      COMMIT_TAG=$( echo "${BUILD_SOURCEBRANCH}" | sed -rn 's/^refs\/tags\/(.*)/\1/p' )
 
       echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin
 
       # Set job-scoped variables
       echo "##vso[task.setvariable variable=REPOSITORY]${REPOSITORY}"
+      echo "##vso[task.setvariable variable=COMMIT_TAG]${COMMIT_TAG}"
     env:
       REGISTRY_PASSWORD: $(REGISTRY_PASSWORD)
     displayName: Before Script
@@ -60,9 +64,11 @@ jobs:
           -t "${REPOSITORY}:${VARIANT}" \
           --label "game_distributor=steamcmd" \
           "${VARIANT}/"
-      docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${IMAGE_ARCHIVE_TAG}"
       if [ "$LATEST" = 'true' ]; then
           docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:latest"
+      fi
+      if [ -n "$COMMIT_TAG" ]; then
+          docker tag "${REPOSITORY}:${VARIANT}" "${REPOSITORY}:${VARIANT}-${COMMIT_TAG}"
       fi
       date
       echo; docker images
@@ -81,12 +87,11 @@ jobs:
   - script: |
       set -e
       # Push the image
-      if [ ! "${NO_PUSH}" = 'true' ]; then
-          date
-          docker push "${REPOSITORY}"
-          date
-      fi
+      date
+      docker push "${REPOSITORY}"
+      date
     displayName: Push SteamCMD Image
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
   - script: |
       docker logout
     displayName: After Script


### PR DESCRIPTION
The docker images pushed currently have no unique tags, which may result in the images being overridden should the image layers change. Adding an archive tag will ensure their persistence in the docker repository.

Additionally, images will only be pushed for branches following the pattern `build/*`.