### PR TITLE
Run CI for all branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,7 @@
 trigger:
   branches:
     include:
-      - build/*
-      - master
+      - '*'
 pr:
   branches:
     include:


### PR DESCRIPTION
Currently, CI processes are only triggered for certain branches. This change will enable CI for all of branches for improved workflow.